### PR TITLE
fix: Use username for Cognito confirmation

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -165,12 +165,12 @@ export function AuthProvider({ children }) {
     }
   }
 
-  const confirmSignUp = async ({ email, code }) => {
+  const confirmSignUp = async ({ code }) => {
     dispatch({ type: actions.SET_LOADING, payload: true })
     dispatch({ type: actions.CLEAR_ERROR })
     
     try {
-      await cognitoConfirmSignUp({ email, code })
+      await cognitoConfirmSignUp({ username: state.pendingVerificationUsername, code })
       
       // Auto-login after successful verification using stored credentials
       const storedPassword = state.pendingVerificationPassword
@@ -269,9 +269,9 @@ export function AuthProvider({ children }) {
     }
   }
 
-  const resendConfirmationCode = async ({ email }) => {
+  const resendConfirmationCode = async () => {
     try {
-      await cognitoResendConfirmationCode({ email })
+      await cognitoResendConfirmationCode({ username: state.pendingVerificationUsername })
       return {
         success: true,
         message: 'Confirmation code sent!',

--- a/src/lib/cognitoAuth.js
+++ b/src/lib/cognitoAuth.js
@@ -74,10 +74,10 @@ export const signUp = ({ username, email, password }) => {
  * @param {string} code - Verification code from email
  * @returns {Promise<string>} Promise resolving to confirmation result
  */
-export const confirmSignUp = ({ email, code }) => {
+export const confirmSignUp = ({ username, code }) => {
   return new Promise((resolve, reject) => {
     const cognitoUser = new CognitoUser({
-      Username: email, // This can be username or email
+      Username: username,
       Pool: userPool,
     })
 
@@ -309,10 +309,10 @@ export const refreshSession = () => {
  * @param {string} email - User's email address
  * @returns {Promise<string>} Promise resolving when code is sent
  */
-export const resendConfirmationCode = ({ email }) => {
+export const resendConfirmationCode = ({ username }) => {
   return new Promise((resolve, reject) => {
     const cognitoUser = new CognitoUser({
-      Username: email,
+      Username: username,
       Pool: userPool,
     })
 

--- a/src/pages/VerifyEmailPage.jsx
+++ b/src/pages/VerifyEmailPage.jsx
@@ -40,7 +40,7 @@ function VerifyEmailPage() {
     }
 
     try {
-      const result = await confirmSignUp({ email, code })
+      const result = await confirmSignUp({ code })
       
       setVerificationSuccess(true)
       setSuccessMessage(result.message)
@@ -68,7 +68,7 @@ function VerifyEmailPage() {
     setResendMessage('')
     
     try {
-      await resendConfirmationCode({ email })
+      await resendConfirmationCode()
       setResendMessage('Verification code sent! Please check your email.')
     } catch (error) {
       console.error('Resend error:', error)


### PR DESCRIPTION
This commit fixes a bug in the sign-up flow where user account confirmation would fail. The issue was caused by using the user's email to confirm the account, while the account was created with a username as the primary identifier.

The following changes have been made:
- `src/lib/cognitoAuth.js`: The `confirmSignUp` and `resendConfirmationCode` functions have been updated to accept a `username` instead of an `email`.
- `src/context/AuthContext.jsx`: The context now uses the stored `pendingVerificationUsername` to call the updated functions in `cognitoAuth.js`.
- `src/pages/VerifyEmailPage.jsx`: The verification page has been updated to call the context functions without passing the email.